### PR TITLE
Fix dart daylight saving feature

### DIFF
--- a/lib/src/dart_date.dart
+++ b/lib/src/dart_date.dart
@@ -1,5 +1,5 @@
-import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
 import 'package:timeago/timeago.dart' as timeago_lib;
 
 class Interval {
@@ -20,24 +20,19 @@ class Interval {
 
   DateTime get end => _start.add(_duration);
 
-  bool includes(DateTime date) =>
-      ((date.isAfter(start) || date.isAtSameMomentAs(start)) &&
-          (date.isBefore(end) || date.isAtSameMomentAs(end)));
+  bool includes(DateTime date) => (date.isAfter(start) || date.isAtSameMomentAs(start)) && (date.isBefore(end) || date.isAtSameMomentAs(end));
 
-  bool contains(Interval interval) =>
-      (includes(interval.start) && includes(interval.end));
+  bool contains(Interval interval) => includes(interval.start) && includes(interval.end);
 
-  bool cross(Interval other) => (includes(other.start) || includes(other.end));
+  bool cross(Interval other) => includes(other.start) || includes(other.end);
 
-  bool equals(Interval other) =>
-      (start.isAtSameMomentAs(other.start) && end.isAtSameMomentAs(other.end));
+  bool equals(Interval other) => start.isAtSameMomentAs(other.start) && end.isAtSameMomentAs(other.end);
 
   Interval union(Interval other) {
     if (cross(other)) {
       if (end.isAfter(other.start) || end.isAtSameMomentAs(other.start)) {
         return Interval(start, other.end);
-      } else if (other.end.isAfter(start) ||
-          other.end.isAtSameMomentAs(start)) {
+      } else if (other.end.isAfter(start) || other.end.isAtSameMomentAs(start)) {
         return Interval(other.start, end);
       } else {
         throw RangeError('Error this: $this; other: $other');
@@ -51,8 +46,7 @@ class Interval {
     if (cross(other)) {
       if (end.isAfter(other.start) || end.isAtSameMomentAs(other.start)) {
         return Interval(other.start, end);
-      } else if (other.end.isAfter(start) ||
-          other.end.isAtSameMomentAs(start)) {
+      } else if (other.end.isAfter(start) || other.end.isAtSameMomentAs(start)) {
         return Interval(other.start, end);
       } else {
         throw RangeError('Error this: $this; other: $other');
@@ -100,15 +94,13 @@ class Interval {
   }
 
   // Operators
-  bool operator <(Interval other) => (start.isBefore(other.start));
+  bool operator <(Interval other) => start.isBefore(other.start);
 
-  bool operator <=(Interval other) =>
-      (start.isBefore(other.start) || start.isAtSameMomentAs(other.start));
+  bool operator <=(Interval other) => start.isBefore(other.start) || start.isAtSameMomentAs(other.start);
 
-  bool operator >(Interval other) => (end.isAfter(other.end));
+  bool operator >(Interval other) => end.isAfter(other.end);
 
-  bool operator >=(Interval other) =>
-      (end.isAfter(other.end) || end.isAtSameMomentAs(other.end));
+  bool operator >=(Interval other) => end.isAfter(other.end) || end.isAtSameMomentAs(other.end);
 
   @override
   String toString() => '<${start} | ${end} | ${duration} >';
@@ -140,9 +132,7 @@ extension Date on DateTime {
     bool isUTC = false,
   }) {
     initializeDateFormatting();
-    return pattern == null
-        ? DateTime.parse(dateString)
-        : DateFormat(pattern, locale).parse(dateString, isUTC);
+    return pattern == null ? DateTime.parse(dateString) : DateFormat(pattern, locale).parse(dateString, isUTC);
   }
 
   /// Create a [Date] object from a Unix timestamp
@@ -180,10 +170,12 @@ extension Date on DateTime {
   Duration diff(DateTime other) => difference(other);
 
   /// Add a certain amount of days to this date
-  DateTime addDays(int amount) => add(Duration(days: amount));
+  DateTime addDays(int amount, [bool ignoreDaylightSavings = false]) =>
+      ignoreDaylightSavings ? DateTime(year, month, day + amount, hour, minute, second, millisecond, microsecond) : add(Duration(days: amount));
 
   /// Add a certain amount of hours to this date
-  DateTime addHours(int amount) => add(Duration(hours: amount));
+  DateTime addHours(int amount, [bool ignoreDaylightSavings = false]) =>
+      ignoreDaylightSavings ? DateTime(year, month, day, hour + amount, minute, second, millisecond, microsecond) : add(Duration(hours: amount));
 
   // TODO: this
   // Date addISOYears(int amount) {
@@ -197,7 +189,8 @@ extension Date on DateTime {
   DateTime addMicroseconds(int amount) => add(Duration(microseconds: amount));
 
   /// Add a certain amount of minutes to this date
-  DateTime addMinutes(int amount) => add(Duration(minutes: amount));
+  DateTime addMinutes(int amount, [bool ignoreDaylightSavings = false]) =>
+      ignoreDaylightSavings ? DateTime(year, month, day, hour, minute + amount, second, millisecond, microsecond) : add(Duration(minutes: amount));
 
   /// Add a certain amount of months to this date
   DateTime addMonths(int amount) => clone.setMonth(month + amount);
@@ -206,7 +199,8 @@ extension Date on DateTime {
   DateTime addQuarters(int amount) => addMonths(amount * 3);
 
   /// Add a certain amount of seconds to this date
-  DateTime addSeconds(int amount) => add(Duration(seconds: amount));
+  DateTime addSeconds(int amount, [bool ignoreDaylightSavings = false]) =>
+      ignoreDaylightSavings ? DateTime(year, month, day, hour, minute, second + amount, millisecond, microsecond) : add(Duration(seconds: amount));
 
   /// Add a certain amount of weeks to this date
   DateTime addWeeks(int amount) => addDays(amount * 7);
@@ -270,12 +264,10 @@ extension Date on DateTime {
   int compare(DateTime other) => compareTo(other);
 
   /// Returns true if left [isBefore] than right
-  static DateTime min(DateTime left, DateTime right) =>
-      (left < right) ? left : right;
+  static DateTime min(DateTime left, DateTime right) => (left < right) ? left : right;
 
   /// Returns true if left [isAfter] than right
-  static DateTime max(DateTime left, DateTime right) =>
-      (left < right) ? right : left;
+  static DateTime max(DateTime left, DateTime right) => (left < right) ? right : left;
 
   /// Compare the two dates and return 1 if the first date [isAfter] the second,
   /// -1 if the first date [isBefore] the second or 0 first date [isEqual] the second.
@@ -291,8 +283,7 @@ extension Date on DateTime {
 
   /// Compare the two dates and return -1 if the first date [isAfter] the second,
   /// 1 if the first date [isBefore] the second or 0 first date [isEqual] the second.
-  static int compareDesc(DateTime dateLeft, DateTime dateRight) =>
-      (-1) * compareAsc(dateLeft, dateRight);
+  static int compareDesc(DateTime dateLeft, DateTime dateRight) => (-1) * compareAsc(dateLeft, dateRight);
 
   // int differenceInCalendarDays(dateLeft, dateRight)
   // int differenceInCalendarISOWeeks(dateLeft, dateRight)
@@ -335,8 +326,7 @@ extension Date on DateTime {
   /// - If [allowFromNow] is passed, format will use the From prefix, ie. a date
   ///   5 minutes from now in 'en' locale will display as '5 minutes from now'
   /// If locales was not loaded previously en would be used use timeago.setLocaleMessages to set them
-  String timeago({String locale, DateTime clock, bool allowFromNow}) =>
-      timeago_lib.format(
+  String timeago({String locale, DateTime clock, bool allowFromNow}) => timeago_lib.format(
         this,
         locale: locale,
         clock: clock,
@@ -481,7 +471,7 @@ extension Date on DateTime {
 
   /// Get the week index
   int get getWeek {
-    Duration diff = startOfWeek.difference(startOfWeekYear);
+    final diff = startOfWeek.difference(startOfWeekYear);
 
     // Round the number of days to the nearest integer
     // because the number of milliseconds in a week is not constant
@@ -491,7 +481,7 @@ extension Date on DateTime {
 
   /// Get the ISO week index
   int get getISOWeek {
-    Duration diff = startOfISOWeek.difference(startOfISOWeekYear);
+    final diff = startOfISOWeek.difference(startOfISOWeekYear);
 
     // Round the number of days to the nearest integer
     // because the number of milliseconds in a week is not constant
@@ -501,11 +491,13 @@ extension Date on DateTime {
 
   /// Get the local week-numbering year
   int get getWeekYear {
-    var startOfNextYear = DateTime(year + 1).startOfWeek;
+    final startOfNextYear = DateTime(year + 1).startOfWeek;
+
     if (millisecondsSinceEpoch >= startOfNextYear.millisecondsSinceEpoch) {
       return year + 1;
     } else {
-      var startOfThisYear = DateTime(year).startOfWeek;
+      final startOfThisYear = DateTime(year).startOfWeek;
+
       if (millisecondsSinceEpoch >= startOfThisYear.millisecondsSinceEpoch) {
         return year;
       } else {
@@ -515,10 +507,10 @@ extension Date on DateTime {
   }
 
   /// Return true if other [isEqual] or [isAfter] to this date
-  bool isSameOrAfter(DateTime other) => (this == other || isAfter(other));
+  bool isSameOrAfter(DateTime other) => this == other || isAfter(other);
 
   /// Return true if other [isEqual] or [isBefore] to this date
-  bool isSameOrBefore(DateTime other) => (this == other || isBefore(other));
+  bool isSameOrBefore(DateTime other) => this == other || isBefore(other);
 
   /// Check if a Object if a [DateTime], use for validation purposes
   static bool isDate(argument) => argument is DateTime;
@@ -554,12 +546,10 @@ extension Date on DateTime {
   bool get isFuture => isAfter(DateTime.now());
 
   /// Is the given date the last day of a month?
-  bool get isLastDayOfMonth =>
-      isSameDay(nextMonth.startOfMonth.subHours(12).startOfDay);
+  bool get isLastDayOfMonth => isSameDay(nextMonth.startOfMonth.subHours(12).startOfDay);
 
   /// Is the given date in the leap year?
-  bool get isLeapYear =>
-      ((year % 400 == 0) || (year % 4 == 0 && year % 100 != 0));
+  bool get isLeapYear => (year % 400 == 0) || (year % 4 == 0 && year % 100 != 0);
 
   /// Return true if this date [isBefore] [Date.now]
   bool get isPast => isBefore(DateTime.now());
@@ -582,8 +572,7 @@ extension Date on DateTime {
   // bool isSameQuarter(dateLeft, dateRight)
 
   /// Check if this date is in the same second than other
-  bool isSameSecond(DateTime other) =>
-      secondsSinceEpoch == other.secondsSinceEpoch;
+  bool isSameSecond(DateTime other) => secondsSinceEpoch == other.secondsSinceEpoch;
 
   // bool isSameWeek(dateLeft, dateRight, [options])
 
@@ -627,11 +616,10 @@ extension Date on DateTime {
   bool get isUTC => isUtc;
 
   /// Return true if this [DateTime] is a saturday or a sunday
-  bool get isWeekend => (day == DateTime.saturday || day == DateTime.sunday);
+  bool get isWeekend => day == DateTime.saturday || day == DateTime.sunday;
 
   /// Checks if a [DateTime] is within a Rage (two dates that makes an [Interval])
-  bool isWithinRange(DateTime startDate, DateTime endDate) =>
-      Interval(startDate, endDate).includes(this);
+  bool isWithinRange(DateTime startDate, DateTime endDate) => Interval(startDate, endDate).includes(this);
 
   /// Checks if a [DateTime] is within an [Interval]
   bool isWithinInterval(Interval interval) => interval.includes(this);
@@ -864,21 +852,19 @@ extension Date on DateTime {
   DateTime get startOfWeek => subtract(Duration(days: weekday)).startOfDay;
 
   /// Get a [DateTime] representing start of year of this [DateTime] in local time.
-  DateTime get startOfYear =>
-      clone.setMonth(DateTime.january, 1, 0, 0, 0, 0, 0);
+  DateTime get startOfYear => clone.setMonth(DateTime.january, 1, 0, 0, 0, 0, 0);
 
   /// Get the start of a local week-numbering year
   DateTime get startOfWeekYear => startOfYear.startOfWeek;
 
   /// Get the start of a local week-numbering year
-  DateTime get startOfISOWeekYear =>
-      DateTime(year, DateTime.january, 4).startOfISOWeek;
+  DateTime get startOfISOWeekYear => DateTime(year, DateTime.january, 4).startOfISOWeek;
 
   /// Get the number of weeks in an ISO week-numbering year
   int get getISOWeeksInYear {
-    var thisYear = startOfISOWeekYear;
-    var nextYear = thisYear.addWeeks(60).startOfISOWeekYear;
-    var diff = nextYear.difference(thisYear);
+    final thisYear = startOfISOWeekYear;
+    final nextYear = thisYear.addWeeks(60).startOfISOWeekYear;
+    final diff = nextYear.difference(thisYear);
     // Round the number of weeks to the nearest integer
     // because the number of milliseconds in a week is not constant
     // (e.g. it's different in the week of the daylight saving time clock shift)
@@ -920,13 +906,11 @@ extension Date on DateTime {
 
   bool operator <(DateTime other) => isBefore(other);
 
-  bool operator <=(DateTime other) =>
-      (isBefore(other) || isAtSameMomentAs(other));
+  bool operator <=(DateTime other) => isBefore(other) || isAtSameMomentAs(other);
 
   bool operator >(DateTime other) => isAfter(other);
 
-  bool operator >=(DateTime other) =>
-      (isAfter(other) || isAtSameMomentAs(other));
+  bool operator >=(DateTime other) => isAfter(other) || isAtSameMomentAs(other);
 
   String toHumanString() => format('E MMM d y H:m:s');
 
@@ -1052,13 +1036,13 @@ extension Date on DateTime {
   }
 
   /// Get UTC [DateTime] from this [DateTime]
-  DateTime get UTC => DateTime.fromMicrosecondsSinceEpoch(
+  DateTime get utc => DateTime.fromMicrosecondsSinceEpoch(
         microsecondsSinceEpoch,
         isUtc: true,
       );
 
   /// Get Local [DateTime] from this [DateTime]
-  DateTime get Local => DateTime.fromMicrosecondsSinceEpoch(
+  DateTime get local => DateTime.fromMicrosecondsSinceEpoch(
         microsecondsSinceEpoch,
         isUtc: false,
       );
@@ -1068,24 +1052,24 @@ extension Date on DateTime {
   }
 
   DateTime operator +(Duration other) {
-    return this.add(other);
+    return add(other);
   }
 }
 
-extension Duration_ on Duration {
+extension DurationExtension on Duration {
   Duration operator -(Duration other) {
-    return Duration(microseconds: this.inMicroseconds - other.inMicroseconds);
+    return Duration(microseconds: inMicroseconds - other.inMicroseconds);
   }
 
   Duration operator +(Duration other) {
-    return Duration(microseconds: this.inMicroseconds + other.inMicroseconds);
+    return Duration(microseconds: inMicroseconds + other.inMicroseconds);
   }
 
   Duration operator *(num other) {
-    return Duration(microseconds: (this.inMicroseconds * other).round());
+    return Duration(microseconds: (inMicroseconds * other).round());
   }
 
   Duration operator /(num other) {
-    return Duration(microseconds: (this.inMicroseconds / other).round());
+    return Duration(microseconds: (inMicroseconds / other).round());
   }
 }


### PR DESCRIPTION
1) Allow disabling Dart's daylight saving feature to a more logical use of `addDays`, `addHours`, `addMinutes` and `addSeconds`.
2) Fixes dictated by Flutter analysis options.