### PR TITLE
Bumped intl version up to 0.17.0-nullsafety.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_date
 description: Date manipulation library. DateTime extensions. Also includes an Interval object.
-version: 1.0.9
+version: 1.0.10
 homepage: https://github.com/xantiagoma/dart_date
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
-  intl: ^0.16.1
+  intl: ^0.17.0-nullsafety.2
   timeago: ^2.0.29
 
 dev_dependencies:


### PR DESCRIPTION
Hi,

After the flutter upgrade to 1.25.0-0.8.1.pre (on the beta channel), flutter_localizations now depends on intl 0.17, while dart_date depends on intl 0.16.1, breaking package resolution on my project.

I'm submitting a pull request to bump up intl to 0.17.0.

Thank you,
Luke