### PR TITLE
Fix week calculation

### DIFF
--- a/lib/src/dart_date.dart
+++ b/lib/src/dart_date.dart
@@ -505,23 +505,31 @@ extension Date on DateTime {
   int get getWeekday => weekday;
 
   /// Get the week index
-  int get getWeek {
-    final diff = startOfWeek.difference(startOfWeekYear);
-
-    // Round the number of days to the nearest integer
-    // because the number of milliseconds in a week is not constant
-    // (e.g. it's different in the week of the daylight saving time clock shift)
-    return (diff.inMilliseconds / MILLISECONDS_IN_WEEK).round();
-  }
+  int get getWeek => addDays(1).getISOWeek;
 
   /// Get the ISO week index
   int get getISOWeek {
-    final diff = startOfISOWeek.difference(startOfISOWeekYear);
+    final woy = ((_ordinalDate - weekday + 10) ~/ 7);
 
-    // Round the number of days to the nearest integer
-    // because the number of milliseconds in a week is not constant
-    // (e.g. it's different in the week of the daylight saving time clock shift)
-    return ((diff.inMilliseconds / MILLISECONDS_IN_WEEK) + 1).round();
+    // If the week number equals zero, it means that the given date belongs to the preceding (week-based) year.
+    if (woy == 0) {
+      // The 28th of December is always in the last week of the year
+      return DateTime(year - 1, 12, 28).getISOWeek;
+    }
+
+    // If the week number equals 53, one must check that the date is not actually in week 1 of the following year
+    if (woy == 53 &&
+        DateTime(year, 1, 1).weekday != DateTime.thursday &&
+        DateTime(year, 12, 31).weekday != DateTime.thursday) {
+      return 1;
+    }
+
+    return woy;
+  }
+
+  int get _ordinalDate {
+    const offsets = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+    return offsets[month - 1] + day + (isLeapYear && month > 2 ? 1 : 0);
   }
 
   /// Get the local week-numbering year
@@ -585,8 +593,7 @@ extension Date on DateTime {
       isSameDay(nextMonth.startOfMonth.subHours(12).startOfDay);
 
   /// Is the given date in the leap year?
-  bool get isLeapYear =>
-      (year % 400 == 0) || (year % 4 == 0 && year % 100 != 0);
+  bool get isLeapYear => year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
 
   /// Return true if this date [isBefore] [Date.now]
   bool get isPast => isBefore(DateTime.now());
@@ -899,18 +906,11 @@ extension Date on DateTime {
   DateTime get startOfWeekYear => startOfYear.startOfWeek;
 
   /// Get the start of a local week-numbering year
-  DateTime get startOfISOWeekYear =>
-      DateTime(year, DateTime.january, 4).startOfISOWeek;
+  DateTime get startOfISOWeekYear => startOfYear.startOfISOWeek;
 
   /// Get the number of weeks in an ISO week-numbering year
   int get getISOWeeksInYear {
-    final thisYear = startOfISOWeekYear;
-    final nextYear = thisYear.addWeeks(60).startOfISOWeekYear;
-    final diff = nextYear.difference(thisYear);
-    // Round the number of weeks to the nearest integer
-    // because the number of milliseconds in a week is not constant
-    // (e.g. it's different in the week of the daylight saving time clock shift)
-    return (diff.inMilliseconds / MILLISECONDS_IN_WEEK).round();
+    return DateTime(year, 12, 28).getISOWeek;
   }
 
   /// Subtracts a [Duration] from this [DateTime]

--- a/lib/src/dart_date.dart
+++ b/lib/src/dart_date.dart
@@ -397,7 +397,7 @@ extension Date on DateTime {
   DateTime get endOfHour => clone.setMinute(59, 59, 999, 999);
 
   /// Return the end of ISO week for this date. The result will be in the local timezone.
-  DateTime get endOfISOWeek => endOfWeek.nextDay;
+  DateTime get endOfISOWeek => startOfISOWeek.addDays(6).endOfDay;
 
   // DateTime endOfISOYear()
 
@@ -511,7 +511,7 @@ extension Date on DateTime {
     // Round the number of days to the nearest integer
     // because the number of milliseconds in a week is not constant
     // (e.g. it's different in the week of the daylight saving time clock shift)
-    return ((diff.inMilliseconds / MILLISECONDS_IN_WEEK) + 1).round();
+    return (diff.inMilliseconds / MILLISECONDS_IN_WEEK).round();
   }
 
   /// Get the ISO week index
@@ -870,7 +870,7 @@ extension Date on DateTime {
   DateTime get startOfHour => clone.setMinute(0, 0, 0, 0);
 
   /// Get a [DateTime] representing start of week (ISO week) of this [DateTime] in local time.
-  DateTime get startOfISOWeek => startOfWeek.nextDay;
+  DateTime get startOfISOWeek => subDays(weekday - 1).startOfDay;
 
   // DateTime startOfISOYear()
 
@@ -888,7 +888,8 @@ extension Date on DateTime {
   static DateTime get startOfToday => today.startOfDay;
 
   /// Get a [DateTime] representing start of week of this [DateTime] in local time.
-  DateTime get startOfWeek => subtract(Duration(days: weekday)).startOfDay;
+  DateTime get startOfWeek =>
+      weekday == DateTime.sunday ? startOfDay : subDays(weekday).startOfDay;
 
   /// Get a [DateTime] representing start of year of this [DateTime] in local time.
   DateTime get startOfYear =>

--- a/test/dart_date_test.dart
+++ b/test/dart_date_test.dart
@@ -49,11 +49,11 @@ void main() {
     });
 
     test('getWeekPreviousYear', () {
-      expect(DateTime(2005, DateTime.january, 1).getWeek, 0);
+      expect(DateTime(2005, DateTime.january, 1).getWeek, 53);
     });
 
     test('getWeekBefore100AD', () {
-      expect(DateTime(7, DateTime.december, 30).getWeek, 52);
+      expect(DateTime(7, DateTime.december, 30).getISOWeek, 52);
     });
 
     test('getISOWeek', () {
@@ -61,11 +61,12 @@ void main() {
     });
 
     test('getISOWeekPreviousYear', () {
-      expect(DateTime(2005, DateTime.january, 2).getISOWeek, 0);
+      expect(DateTime(2005, DateTime.january, 2).getISOWeek, 53);
     });
 
-    test('getISOWeekBefore100AD', () {
-      expect(DateTime(7, DateTime.december, 30).getISOWeek, 52);
+    test('ISOWeek - Week compare', () {
+      expect(DateTime(1922, DateTime.january, 1).getWeek, 1);
+      expect(DateTime(1922, DateTime.january, 1).getISOWeek, 52);
     });
 
     test('getWeekYear', () {
@@ -84,7 +85,7 @@ void main() {
 
     test('startOfISOWeekYear', () {
       expect(DateTime(2005, DateTime.july, 2).startOfISOWeekYear,
-          DateTime(2005, DateTime.january, 3));
+          DateTime(2004, DateTime.december, 27));
     });
 
     test('startOfISOWeekYearOnFirstJanuary', () {

--- a/test/dart_date_test.dart
+++ b/test/dart_date_test.dart
@@ -45,11 +45,11 @@ void main() {
 
   group('Week', () {
     test('getWeek', () {
-      expect(DateTime(2005, DateTime.january, 3).getWeek, 2);
+      expect(DateTime(2005, DateTime.january, 2).getWeek, 1);
     });
 
     test('getWeekPreviousYear', () {
-      expect(DateTime(2005, DateTime.january, 2).getWeek, 1);
+      expect(DateTime(2005, DateTime.january, 1).getWeek, 0);
     });
 
     test('getWeekBefore100AD', () {
@@ -107,6 +107,26 @@ void main() {
 
     test('getISOWeeksInYearBefore100AD', () {
       expect(DateTime(4, DateTime.january, 4).getISOWeeksInYear, 53);
+    });
+
+    test('startOfWeek', () {
+      expect(DateTime(2022, DateTime.january, 9).startOfWeek,
+          DateTime(2022, DateTime.january, 9).startOfDay);
+    });
+
+    test('endOfWeek', () {
+      expect(DateTime(2022, DateTime.january, 9).endOfWeek,
+          DateTime(2022, DateTime.january, 15).endOfDay);
+    });
+
+    test('startOfISOWeek', () {
+      expect(DateTime(2022, DateTime.january, 9).startOfISOWeek,
+          DateTime(2022, DateTime.january, 3).startOfDay);
+    });
+
+    test('endOfISOWeek', () {
+      expect(DateTime(2022, DateTime.january, 9).endOfISOWeek,
+          DateTime(2022, DateTime.january, 9).endOfDay);
     });
   });
 }


### PR DESCRIPTION
I fixed week start/end calculation. Also fixed week number test. `getWeek` was wrongly tested to 2nd and 3rd day. 2005 starts with saturday. 2th is the first day of week and 3rd of first day of iso week.
Also fixed week number do not return `0` if it is in last year (the expected operation is return last week of past year)

<img width="290" alt="Képernyőfotó 2022-01-01 - 19 54 35" src="https://user-images.githubusercontent.com/536799/147858021-d5b8ce8a-bfd5-4ada-ba42-056f20dd039e.png">
 