### PR TITLE
Fix Interval intersection

### DIFF
--- a/lib/src/dart_date.dart
+++ b/lib/src/dart_date.dart
@@ -53,7 +53,7 @@ class Interval {
 
   Interval intersection(Interval other) {
     if (cross(other)) {
-      if (start.isAfter(other.start)) {
+      if (start.isAfter(other.start) || start.isAtSameMomentAs(other.start)) {
         return Interval(start, other.end);
       } else {
         return Interval(other.start, end);

--- a/lib/src/dart_date.dart
+++ b/lib/src/dart_date.dart
@@ -53,13 +53,10 @@ class Interval {
 
   Interval intersection(Interval other) {
     if (cross(other)) {
-      if (end.isAfter(other.start) || end.isAtSameMomentAs(other.start)) {
-        return Interval(other.start, end);
-      } else if (other.end.isAfter(start) ||
-          other.end.isAtSameMomentAs(start)) {
-        return Interval(other.start, end);
+      if (start.isAfter(other.start)) {
+        return Interval(start, other.end);
       } else {
-        throw RangeError('Error this: $this; other: $other');
+        return Interval(other.start, end);
       }
     } else {
       throw RangeError('Intervals don\'t cross');

--- a/test/dart_date_test.dart
+++ b/test/dart_date_test.dart
@@ -130,4 +130,37 @@ void main() {
           DateTime(2022, DateTime.january, 9).endOfDay);
     });
   });
+
+  group('Interval', () {
+    test('intersection first before second', () {
+      final firstInterval = Interval(DateTime(2022), DateTime(2024));
+      final secondInterval = Interval(DateTime(2023), DateTime(2025));
+
+      expect(
+          firstInterval
+              .intersection(secondInterval)
+              .equals(Interval(DateTime(2023), DateTime(2024))),
+          true);
+    });
+    test('intersection second before first', () {
+      final firstInterval = Interval(DateTime(2023), DateTime(2025));
+      final secondInterval = Interval(DateTime(2022), DateTime(2024));
+
+      expect(
+          firstInterval
+              .intersection(secondInterval)
+              .equals(Interval(DateTime(2023), DateTime(2024))),
+          true);
+    });
+
+    test("intersection throws if they don't crossing", () {
+      final firstInterval = Interval(DateTime(2023), DateTime(2025));
+      final secondInterval = Interval(DateTime(2026), DateTime(2027));
+
+      expect(
+        () => firstInterval.intersection(secondInterval),
+        throwsA(isA<RangeError>()),
+      );
+    });
+  });
 }

--- a/test/dart_date_test.dart
+++ b/test/dart_date_test.dart
@@ -152,8 +152,28 @@ void main() {
               .equals(Interval(DateTime(2023), DateTime(2024))),
           true);
     });
+    test('intersection start is equal', () {
+      final firstInterval = Interval(DateTime(2022), DateTime(2025));
+      final secondInterval = Interval(DateTime(2022), DateTime(2024));
 
-    test("intersection throws if they don't crossing", () {
+      expect(
+          firstInterval
+              .intersection(secondInterval)
+              .equals(Interval(DateTime(2022), DateTime(2024))),
+          true);
+    });
+    test('intersection end is equal', () {
+      final firstInterval = Interval(DateTime(2023), DateTime(2025));
+      final secondInterval = Interval(DateTime(2022), DateTime(2025));
+
+      expect(
+          firstInterval
+              .intersection(secondInterval)
+              .equals(Interval(DateTime(2023), DateTime(2025))),
+          true);
+    });
+
+    test("intersection throws if the intervals don't cross", () {
       final firstInterval = Interval(DateTime(2023), DateTime(2025));
       final secondInterval = Interval(DateTime(2026), DateTime(2027));
 


### PR DESCRIPTION
Most of the time, the interval intersection method was incorrect, and it produced different results when intersecting x from y and y from x, which is incorrect and should always be the same.

I've added some tests to make sure it's working properly.