### PR TITLE
Allow newer intl versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  intl: ^0.17.0
+  intl: ">=0.17.0 <0.19.0"
   timeago: ^3.0.2
 
 dev_dependencies:


### PR DESCRIPTION
This PR allows newer intl versions and thus the usage of 3.10.x pre-release versions of Flutter.

Fixes #26 
