### PR TITLE
fix: intersection on interval containing the other interval

### DIFF
--- a/lib/src/dart_date.dart
+++ b/lib/src/dart_date.dart
@@ -52,15 +52,18 @@ class Interval {
   }
 
   Interval intersection(Interval other) {
-    if (cross(other)) {
-      if (start.isAfter(other.start) || start.isAtSameMomentAs(other.start)) {
-        return Interval(start, other.end);
-      } else {
-        return Interval(other.start, end);
+    if (!cross(other)) {
+      if (other.contains(this)) {
+        return this;
       }
-    } else {
+
       throw RangeError('Intervals don\'t cross');
     }
+
+    final intersectionStart = Date.max(start, other.start);
+    final intersectionEnd = Date.min(end, other.end);
+
+    return Interval(intersectionStart, intersectionEnd);
   }
 
   Interval? difference(Interval other) {

--- a/test/dart_date_test.dart
+++ b/test/dart_date_test.dart
@@ -190,5 +190,27 @@ void main() {
         throwsA(isA<RangeError>()),
       );
     });
+
+    test('intersection first is inside second', () {
+      final firstInterval = Interval(DateTime(2023), DateTime(2024));
+      final secondInterval = Interval(DateTime(2022), DateTime(2025));
+
+      expect(
+          firstInterval
+              .intersection(secondInterval)
+              .equals(Interval(DateTime(2023), DateTime(2024))),
+          true);
+    });
+
+    test('intersection second is inside first', () {
+      final firstInterval = Interval(DateTime(2022), DateTime(2025));
+      final secondInterval = Interval(DateTime(2023), DateTime(2024));
+
+      expect(
+          firstInterval
+              .intersection(secondInterval)
+              .equals(Interval(DateTime(2023), DateTime(2024))),
+          true);
+    });
   });
 }


### PR DESCRIPTION
```dart
big = (2000, 2020)
small = (2005,2010)

small.intersection(big) == big.intersection(small) == (2005,2010)
```