### PR TITLE
[BREAKING CHANGE] Fix eachDay function

### DIFF
--- a/lib/src/dart_date.dart
+++ b/lib/src/dart_date.dart
@@ -366,7 +366,10 @@ extension Date on DateTime {
       );
 
   /// Return an Iterable of dates which is inclusive to [this] but exclusive to [date]
-  Iterable<DateTime> eachDay(DateTime date) sync* {
+  Iterable<DateTime> eachDay(
+    DateTime date, {
+    bool ignoreDaylightSavings = false,
+  }) sync* {
     if (isSameDay(date)) {
       yield date.startOfDay;
 
@@ -376,7 +379,7 @@ extension Date on DateTime {
     final daysDiff = differenceInDays(date);
 
     for (var i = 0; i != daysDiff; i += daysDiff.sign) {
-      yield this.addDays(-i);
+      yield this.addDays(-i, ignoreDaylightSavings);
     }
   }
 

--- a/lib/src/dart_date.dart
+++ b/lib/src/dart_date.dart
@@ -374,13 +374,9 @@ extension Date on DateTime {
     }
 
     final daysDiff = differenceInDays(date);
-    final step = daysDiff.isNegative ? 1 : -1;
-    final absDays = daysDiff.abs();
 
-    var current = this;
-    for (var i = 0; i < absDays; i++) {
-      yield current;
-      current = current.addDays(step);
+    for (var i = 0; i != daysDiff; i += daysDiff.sign) {
+      yield this.addDays(-i);
     }
   }
 

--- a/lib/src/dart_date.dart
+++ b/lib/src/dart_date.dart
@@ -365,25 +365,22 @@ extension Date on DateTime {
         allowFromNow: allowFromNow ?? false,
       );
 
-  /// Return the array of dates within the specified range.
+  /// Return an Iterable of dates which is inclusive to [this] but exclusive to [date]
   Iterable<DateTime> eachDay(DateTime date) sync* {
     if (isSameDay(date)) {
       yield date.startOfDay;
-    } else {
-      final difference = diff(date);
-      final days = difference.abs().inDays;
-      var current = date.startOfDay;
-      if (difference.isNegative) {
-        for (var i = 0; i < days; i++) {
-          yield current;
-          current = current.nextDay;
-        }
-      } else {
-        for (var i = 0; i < days; i++) {
-          yield current;
-          current = current.nextDay;
-        }
-      }
+
+      return;
+    }
+
+    final daysDiff = differenceInDays(date);
+    final step = daysDiff.isNegative ? 1 : -1;
+    final absDays = daysDiff.abs();
+
+    var current = this;
+    for (var i = 0; i < absDays; i++) {
+      yield current;
+      current = current.addDays(step);
     }
   }
 

--- a/test/dart_date_test.dart
+++ b/test/dart_date_test.dart
@@ -41,6 +41,41 @@ void main() {
       expect(Date.parse('September 12 2012', pattern: 'MMMM dd y').isLeapYear,
           true);
     });
+
+    test('eachDay', () {
+      final start = DateTime(2023, 10, 10); // October 10th, 2023
+      final end = DateTime(2023, 10, 18); // October 18th, 2023
+
+      // Should produce an Iterable that has the 10th to 18th.
+      final toTest = start.eachDay(end);
+      final expected = [
+        DateTime(2023, 10, 10),
+        DateTime(2023, 10, 11),
+        DateTime(2023, 10, 12),
+        DateTime(2023, 10, 13),
+        DateTime(2023, 10, 14),
+        DateTime(2023, 10, 15),
+        DateTime(2023, 10, 16),
+        DateTime(2023, 10, 17),
+      ];
+
+      expect(toTest, orderedEquals(expected));
+
+      // Should produce an Iterable that has the 18th to 11th (reverse).
+      final toTestReverse = end.eachDay(start);
+      final expectedReverse = [
+        DateTime(2023, 10, 18),
+        DateTime(2023, 10, 17),
+        DateTime(2023, 10, 16),
+        DateTime(2023, 10, 15),
+        DateTime(2023, 10, 14),
+        DateTime(2023, 10, 13),
+        DateTime(2023, 10, 12),
+        DateTime(2023, 10, 11),
+      ];
+
+      expect(toTestReverse, orderedEquals(expectedReverse));
+    });
   });
 
   group('Week', () {

--- a/test/dart_date_test.dart
+++ b/test/dart_date_test.dart
@@ -46,6 +46,8 @@ void main() {
       final start = DateTime(2023, 10, 10); // October 10th, 2023
       final end = DateTime(2023, 10, 18); // October 18th, 2023
 
+      expect(start.eachDay(start), orderedEquals([start]));
+
       // Should produce an Iterable that has the 10th to 18th.
       final toTest = start.eachDay(end);
       final expected = [


### PR DESCRIPTION
This package had a broken `eachDay` function where the output would be outside the range if `this` was before `date`. With my change, here is the difference between the outputs:

```dart
void main() {
  final start = DateTime(2023, 10, 10);
  final end = DateTime(2023, 10, 18);

  print(start.eachDay(end).toList(growable: false));
}
```

### Old (current):
```
[2023-10-18 00:00:00.000, 2023-10-19 00:00:00.000, 2023-10-20 00:00:00.000, 2023-10-21 00:00:00.000, 2023-10-22 00:00:00.000, 2023-10-23 00:00:00.000, 2023-10-24 00:00:00.000, 2023-10-25 00:00:00.000]
```

When we reverse `start` and `end` (`end.eachDay(start)`):
```
[2023-10-10 00:00:00.000, 2023-10-11 00:00:00.000, 2023-10-12 00:00:00.000, 2023-10-13 00:00:00.000, 2023-10-14 00:00:00.000, 2023-10-15 00:00:00.000, 2023-10-16 00:00:00.000, 2023-10-17 00:00:00.000]
```

It looks correct, though the list is still in ascending order.

### New (this change):
```
[2023-10-10 00:00:00.000, 2023-10-11 00:00:00.000, 2023-10-12 00:00:00.000, 2023-10-13 00:00:00.000, 2023-10-14 00:00:00.000, 2023-10-15 00:00:00.000, 2023-10-16 00:00:00.000, 2023-10-17 00:00:00.000]
```

When we reverse `start` and `end` (`end.eachDay(start)`):
```
[2023-10-18 00:00:00.000, 2023-10-17 00:00:00.000, 2023-10-16 00:00:00.000, 2023-10-15 00:00:00.000, 2023-10-14 00:00:00.000, 2023-10-13 00:00:00.000, 2023-10-12 00:00:00.000, 2023-10-11 00:00:00.000]
```