### PR TITLE
Support intl 0.19.0 (and Flutter 3.22.0)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,10 +4,10 @@ version: 1.3.2
 homepage: https://github.com/xantiagoma/dart_date
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 
 dependencies:
-  intl: ">=0.17.0 <0.19.0"
+  intl: ">=0.17.0 <0.20.0"
   timeago: ^3.0.2
 
 dev_dependencies:


### PR DESCRIPTION
Both other PRs on this (#33 and #35) had a core problem: They unnecessarily and artificially restrain `intl` and `sdk` bounds, which will again cause even more users to complain about it.
This PR just updates the upper bounds such that everyone wins!

Closes #33
Closes #35
Fixes #36
