### PR TITLE
fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ difference(Interval other) → Interval
 equals(Interval other) → bool
 includes(DateTime date) → bool
 intersection(Interval other) → Interval
-symetricDiffetence(Interval other) → List<Interval>
+symmetricDifference(Interval other) → List<Interval>
 toString() → String
 union(Interval other) → Interval
 

--- a/lib/src/dart_date.dart
+++ b/lib/src/dart_date.dart
@@ -88,7 +88,7 @@ class Interval {
     }
   }
 
-  List<Interval?> symetricDiffetence(Interval other) {
+  List<Interval?> symmetricDifference(Interval other) {
     final list = <Interval?>[null, null];
     try {
       list[0] = difference(other);


### PR DESCRIPTION
Fixes small typos in name of one method.

"symetricDiffetence" should be "symmetricDifference"

https://en.wikipedia.org/wiki/Symmetric_difference

NOTE: I didn't see this method used in a test anywhere. Are there some missing tests for `symmetricDifference`?