### PR TITLE
fix: changes on Interval (allow negative), fixes on extension

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[tools]
+dart = "latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,34 @@
 # Changelog
 
+## 1.4.0
+
+- **!!! BREAKING CHANGE** `Interval` can accept negative values
+- Some methods that used to throw an error now return null instead
+- Fix type with `symetricDifference` to `symmetricDifference`, marking the other one as deprecated @praiaBarryTolnas #39
+- **!!! BREAKING CHANGE** Change extension name from `Date` to `DateTimeExtension` @tjarvstrand #38 - static methods are now exported from `DateTimeExtension._` instead of `Date._`
+
 ## 1.3.3
+
 - Support `intl` v0.19.0 and Dart 3.0, thanks to @ThexXTURBOXx
 
 ## 1.3.2
+
 - fix `isWeekend`
 
 ## 1.3.1
+
 - Merge [fix: intersection on interval containing the other interval #28](https://github.com/xantiagoma/dart_date/pull/28)
 
 ## 1.3.0
+
 - Merge [[BREAKING CHANGE] Fix eachDay function #30](https://github.com/xantiagoma/dart_date/pull/30)
 
 ## 1.2.2
+
 - Update dependencies
 
 ## 1.2.1
+
 - Merge [Add setWeekDay function #24](https://github.com/xantiagoma/dart_date/pull/24)
 - Merge [Fix Interval intersection #22](https://github.com/xantiagoma/dart_date/pull/22)
 - Merge [Update README.md #21](https://github.com/xantiagoma/dart_date/pull/21)

--- a/example/dart_date_example.dart
+++ b/example/dart_date_example.dart
@@ -4,7 +4,8 @@ main(List<String> args) {
   const pattern = '\'Heute ist\' dd-MMMM-yyyy';
   final n = DateTime.now();
   final de_String = DateTime.now().format(pattern, 'de_DE');
-  final de_Date = Date.parse(de_String, pattern: pattern, locale: 'de_DE');
+  final de_Date =
+      DateTimeExtension.parse(de_String, pattern: pattern, locale: 'de_DE');
   print(
     'DE (String): $de_String',
   );
@@ -33,16 +34,18 @@ main(List<String> args) {
   )!;
   print('Closest to now ($now): $closest (${closest.timeago()})');
 
-  print(Date.today is DateTime);
+  print(DateTimeExtension.today is DateTime);
 
   print("Human String: " +
       DateTime.parse('2014-11-20T16:51:30.000Z').toHumanString());
 
-  print("Yesterday: " + (Date.today - Duration(days: 1)).toString());
-  print("Tomorrow: " + (Date.today + Duration(days: 1)).toString());
+  print(
+      "Yesterday: " + (DateTimeExtension.today - Duration(days: 1)).toString());
+  print(
+      "Tomorrow: " + (DateTimeExtension.today + Duration(days: 1)).toString());
 
   print(Duration(days: 1) + Duration(hours: 12, minutes: 5));
   print(Duration(days: 1) - Duration(hours: 12, minutes: 5));
   print(Duration(hours: 1) * 2.5);
-  print(Duration(hours: 1) / 70);
+  print(Duration(hours: 1) ~/ 70);
 }

--- a/lib/dart_date.dart
+++ b/lib/dart_date.dart
@@ -1,3 +1,4 @@
 library dart_date;
 
 export 'src/dart_date.dart';
+export 'src/interval.dart';

--- a/lib/src/interval.dart
+++ b/lib/src/interval.dart
@@ -1,0 +1,155 @@
+import 'package:dart_date/src/dart_date.dart';
+
+class Interval {
+  late final DateTime _referenceDate;
+  late final Duration _duration;
+
+  Interval(DateTime start, DateTime end) {
+    _referenceDate = start;
+    _duration = end.difference(start);
+  }
+
+  Interval.fromStart(DateTime start, Duration duration)
+      : _referenceDate = start,
+        _duration = duration;
+
+  Interval.fromEnd(DateTime end, Duration duration)
+      : _referenceDate = end,
+        _duration = -duration;
+
+  Interval.fromMiddle(DateTime middle, Duration duration) {
+    _referenceDate = middle.subtract(duration ~/ 2);
+    _duration = duration;
+  }
+
+  DateTime get start =>
+      _duration.isNegative ? _referenceDate.add(_duration) : _referenceDate;
+  DateTime get end =>
+      _duration.isNegative ? _referenceDate : _referenceDate.add(_duration);
+  Duration get duration => end.difference(start);
+
+  DateTime get middle => start.add(duration ~/ 2);
+
+  Interval setStart(DateTime val) => Interval(val, end);
+  Interval setEnd(DateTime val) => Interval(start, val);
+
+  Interval setDurationFromStart(Duration val) => Interval.fromStart(start, val);
+
+  Interval setDurationFromEnd(Duration val) => Interval.fromEnd(end, val);
+
+  Interval setDurationFromMiddle(Duration val) =>
+      Interval.fromMiddle(middle, val);
+
+  bool includes(DateTime date) =>
+      date.isSameOrAfter(start) && date.isSameOrBefore(end);
+
+  bool contains(Interval interval) =>
+      includes(interval.start) && includes(interval.end);
+
+  bool cross(Interval other) => includes(other.start) || includes(other.end);
+
+  bool equals(Interval other) =>
+      start.isAtSameMomentAs(other.start) && end.isAtSameMomentAs(other.end);
+
+  Interval union(Interval other) {
+    if (cross(other)) {
+      if (end.isAfter(other.start) || end.isAtSameMomentAs(other.start)) {
+        return Interval(start, other.end);
+      } else if (other.end.isAfter(start) ||
+          other.end.isAtSameMomentAs(start)) {
+        return Interval(other.start, end);
+      } else {
+        throw RangeError('Error this: $this; other: $other');
+      }
+    } else {
+      throw RangeError('Intervals don\'t cross');
+    }
+  }
+
+  Interval? intersection(Interval other) {
+    if (this.end.isBefore(other.start) || other.end.isBefore(this.start)) {
+      // No overlap
+      return null;
+    }
+
+    DateTime intersectionStart =
+        this.start.isAfter(other.start) ? this.start : other.start;
+    DateTime intersectionEnd =
+        this.end.isBefore(other.end) ? this.end : other.end;
+
+    return Interval(intersectionStart, intersectionEnd);
+  }
+
+  Interval? difference(Interval other) {
+    if (other == this) {
+      return null;
+    } else if (this <= other) {
+      // | this | | other |
+      if (end.isBefore(other.start)) {
+        return this;
+      } else {
+        return Interval(start, other.start);
+      }
+    } else if (this >= other) {
+      // | other | | this |
+      if (other.end.isBefore(start)) {
+        return this;
+      } else {
+        return Interval(other.end, end);
+      }
+    } else {
+      throw RangeError('Error this: $this; other: $other');
+    }
+  }
+
+  List<Interval> symmetricDifference(Interval other) {
+    final first = this.start.isBefore(other.start) ? this : other;
+    final second = this.start.isBefore(other.start) ? other : this;
+
+    if (first.end.isBefore(other.start) || second.end.isBefore(first.start)) {
+      // No overlap, return both intervals
+      return [first, second];
+    }
+
+    List<Interval> result = [];
+
+    if (first.start.isBefore(second.start)) {
+      result.add(Interval(first.start, second.start));
+    } else if (second.start.isBefore(first.start)) {
+      result.add(Interval(second.start, first.start));
+    }
+
+    if (first.end.isAfter(second.end)) {
+      result.add(Interval(second.end, first.end));
+    } else if (second.end.isAfter(first.end)) {
+      result.add(Interval(first.end, second.end));
+    }
+
+    return result;
+  }
+
+  /**
+   * @deprecated use [symmetricDifference] instead
+   */
+  @Deprecated('use symmetricDifference instead')
+  List<Interval?> symetricDifference(Interval other) {
+    return this.symmetricDifference(other);
+  }
+
+  // Operators
+  bool operator <(Interval other) => start.isBefore(other.start);
+
+  bool operator <=(Interval other) =>
+      start.isBefore(other.start) || start.isAtSameMomentAs(other.start);
+
+  bool operator >(Interval other) => end.isAfter(other.end);
+
+  bool operator >=(Interval other) =>
+      end.isAfter(other.end) || end.isAtSameMomentAs(other.end);
+
+  bool operator ==(Object other) =>
+      other is Interval && start == other.start && end == other.end;
+
+  @override
+  String toString() => '<${start} | ${end} | ${duration} >';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_date
 description: Date manipulation library. DateTime extensions. Also includes an Interval object.
-version: 1.3.3
+version: 1.4.0
 homepage: https://github.com/xantiagoma/dart_date
 
 environment:

--- a/test/dart_date_test.dart
+++ b/test/dart_date_test.dart
@@ -4,19 +4,20 @@ import 'package:test/test.dart';
 void main() {
   group('Getters', () {
     test('timestamp', () {
-      expect(Date.unix(0).timestamp, 0);
-      expect(Date.parse('1996-03-29T11:11:11.011Z').timestamp, 828097871011);
+      expect(DateTimeExtension.unix(0).timestamp, 0);
+      expect(DateTimeExtension.parse('1996-03-29T11:11:11.011Z').timestamp,
+          828097871011);
     });
 
     test('isFirstDayOfMonth', () {
       expect(DateTime(2011, 2, 1, 11).isFirstDayOfMonth, true);
       expect(
-          Date.parse('November 01 2018, 9:14:29 PM',
+          DateTimeExtension.parse('November 01 2018, 9:14:29 PM',
                   pattern: 'MMMM dd y, h:mm:ss a')
               .isFirstDayOfMonth,
           true);
       expect(
-          Date.parse('November 30 2011, 0:14:29 PM',
+          DateTimeExtension.parse('November 30 2011, 0:14:29 PM',
                   pattern: 'MMMM dd y, h:mm:ss a')
               .isFirstDayOfMonth,
           false);
@@ -25,12 +26,12 @@ void main() {
     test('isLastDayOfMonth', () {
       expect(DateTime(2011, 2, 1, 11).isLastDayOfMonth, false);
       expect(
-          Date.parse('November 01 2018, 9:14:29 PM',
+          DateTimeExtension.parse('November 01 2018, 9:14:29 PM',
                   pattern: 'MMMM dd y, h:mm:ss a')
               .isLastDayOfMonth,
           false);
       expect(
-          Date.parse('November 30 2011, 0:14:29 PM',
+          DateTimeExtension.parse('November 30 2011, 0:14:29 PM',
                   pattern: 'MMMM dd y, h:mm:ss a')
               .isLastDayOfMonth,
           true);
@@ -38,7 +39,9 @@ void main() {
 
     test('isLeapYear', () {
       expect(DateTime(2011, 2, 1, 11).isLeapYear, false);
-      expect(Date.parse('September 12 2012', pattern: 'MMMM dd y').isLeapYear,
+      expect(
+          DateTimeExtension.parse('September 12 2012', pattern: 'MMMM dd y')
+              .isLeapYear,
           true);
     });
 
@@ -187,81 +190,6 @@ void main() {
       // Other days
       expect(DateTime(2022, DateTime.january, 7).isWeekend, false);
       expect(DateTime(2022, DateTime.january, 10).isWeekend, false);
-    });
-  });
-
-  group('Interval', () {
-    test('intersection first before second', () {
-      final firstInterval = Interval(DateTime(2022), DateTime(2024));
-      final secondInterval = Interval(DateTime(2023), DateTime(2025));
-
-      expect(
-          firstInterval
-              .intersection(secondInterval)
-              .equals(Interval(DateTime(2023), DateTime(2024))),
-          true);
-    });
-    test('intersection second before first', () {
-      final firstInterval = Interval(DateTime(2023), DateTime(2025));
-      final secondInterval = Interval(DateTime(2022), DateTime(2024));
-
-      expect(
-          firstInterval
-              .intersection(secondInterval)
-              .equals(Interval(DateTime(2023), DateTime(2024))),
-          true);
-    });
-    test('intersection start is equal', () {
-      final firstInterval = Interval(DateTime(2022), DateTime(2025));
-      final secondInterval = Interval(DateTime(2022), DateTime(2024));
-
-      expect(
-          firstInterval
-              .intersection(secondInterval)
-              .equals(Interval(DateTime(2022), DateTime(2024))),
-          true);
-    });
-    test('intersection end is equal', () {
-      final firstInterval = Interval(DateTime(2023), DateTime(2025));
-      final secondInterval = Interval(DateTime(2022), DateTime(2025));
-
-      expect(
-          firstInterval
-              .intersection(secondInterval)
-              .equals(Interval(DateTime(2023), DateTime(2025))),
-          true);
-    });
-
-    test("intersection throws if the intervals don't cross", () {
-      final firstInterval = Interval(DateTime(2023), DateTime(2025));
-      final secondInterval = Interval(DateTime(2026), DateTime(2027));
-
-      expect(
-        () => firstInterval.intersection(secondInterval),
-        throwsA(isA<RangeError>()),
-      );
-    });
-
-    test('intersection first is inside second', () {
-      final firstInterval = Interval(DateTime(2023), DateTime(2024));
-      final secondInterval = Interval(DateTime(2022), DateTime(2025));
-
-      expect(
-          firstInterval
-              .intersection(secondInterval)
-              .equals(Interval(DateTime(2023), DateTime(2024))),
-          true);
-    });
-
-    test('intersection second is inside first', () {
-      final firstInterval = Interval(DateTime(2022), DateTime(2025));
-      final secondInterval = Interval(DateTime(2023), DateTime(2024));
-
-      expect(
-          firstInterval
-              .intersection(secondInterval)
-              .equals(Interval(DateTime(2023), DateTime(2024))),
-          true);
     });
   });
 }

--- a/test/interval_test.dart
+++ b/test/interval_test.dart
@@ -1,0 +1,322 @@
+import 'package:dart_date/dart_date.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Interval', () {
+    group("constructors", () {
+      test('default constructor', () {
+        final interval = Interval(DateTime(2022), DateTime(2024));
+        expect(interval.start, DateTime(2022));
+        expect(interval.end, DateTime(2024));
+      });
+      test('from start', () {
+        final interval =
+            Interval.fromStart(DateTime(2022), Duration(days: 365));
+        expect(interval.start, DateTime(2022));
+        expect(interval.end, DateTime(2023));
+      });
+      test('from end', () {
+        final interval = Interval.fromEnd(DateTime(2022), Duration(days: 365));
+        expect(interval.start, DateTime(2021));
+        expect(interval.end, DateTime(2022));
+      });
+      test('from middle', () {
+        final interval =
+            Interval.fromMiddle(DateTime(2022), Duration(days: 365));
+        expect(interval.start, DateTime(2021, 7, 2, 12));
+        expect(interval.end, DateTime(2022, 7, 2, 12));
+      });
+
+      test('from start and negative duration', () {
+        final interval =
+            Interval.fromStart(DateTime(2022), Duration(days: -365));
+        expect(interval.start, DateTime(2021));
+        expect(interval.end, DateTime(2022));
+      });
+      test('from end and negative duration', () {
+        final interval = Interval.fromEnd(DateTime(2022), Duration(days: -365));
+        expect(interval.start, DateTime(2022));
+        expect(interval.end, DateTime(2023));
+      });
+      test('from middle and negative duration', () {
+        final interval =
+            Interval.fromMiddle(DateTime(2022), Duration(days: -365));
+        expect(interval.start, DateTime(2021, 7, 2, 12));
+        expect(interval.end, DateTime(2022, 7, 2, 12));
+      });
+    });
+
+    group("start", () {
+      test('first before second', () {
+        final interval = Interval(DateTime(2022), DateTime(2024));
+        expect(interval.start, DateTime(2022));
+      });
+      test('second before first', () {
+        final interval = Interval(DateTime(2023), DateTime(2025));
+        expect(interval.start, DateTime(2023));
+      });
+
+      test("first and second is same day", () {
+        final interval = Interval(DateTime(2022), DateTime(2022));
+        expect(interval.start, DateTime(2022));
+        expect(interval.end, DateTime(2022));
+        expect(interval.duration, Duration.zero);
+      });
+    });
+
+    group("end", () {
+      test('first before second', () {
+        final interval = Interval(DateTime(2022), DateTime(2024));
+        expect(interval.end, DateTime(2024));
+      });
+      test('second before first', () {
+        final interval = Interval(DateTime(2023), DateTime(2025));
+        expect(interval.end, DateTime(2025));
+      });
+
+      test("first and second is same day", () {
+        final interval = Interval(DateTime(2022), DateTime(2022));
+        expect(interval.start, DateTime(2022));
+        expect(interval.end, DateTime(2022));
+        expect(interval.duration, Duration.zero);
+      });
+    });
+
+    group("duration", () {
+      test('first before second', () {
+        final interval = Interval(DateTime(2022), DateTime(2023));
+        expect(interval.duration, Duration(days: 365));
+      });
+      test('second before first', () {
+        final interval = Interval(DateTime(2023), DateTime(2022));
+        expect(interval.duration, Duration(days: 365));
+      });
+    });
+
+    group("setStart", () {
+      test('new start is before old start', () {
+        final interval = Interval(DateTime(2022), DateTime(2024));
+        final newInterval = interval.setStart(DateTime(2023));
+        expect(newInterval.start, DateTime(2023));
+        expect(newInterval.end, DateTime(2024));
+      });
+
+      test('new start is after old start', () {
+        final interval = Interval(DateTime(2022), DateTime(2024));
+        final newInterval = interval.setStart(DateTime(2021));
+        expect(newInterval.start, DateTime(2021));
+        expect(newInterval.end, DateTime(2024));
+      });
+
+      test('new start is same as old start', () {
+        final interval = Interval(DateTime(2022), DateTime(2024));
+        final newInterval = interval.setStart(DateTime(2022));
+        expect(newInterval.start, DateTime(2022));
+        expect(newInterval.end, DateTime(2024));
+      });
+
+      test('new start is same as old end', () {
+        final interval = Interval(DateTime(2022), DateTime(2024));
+        final newInterval = interval.setStart(DateTime(2024));
+        expect(newInterval.start, DateTime(2024));
+        expect(newInterval.end, DateTime(2024));
+      });
+
+      test('new start if after old end', () {
+        final interval = Interval(DateTime(2022), DateTime(2024));
+        final newInterval = interval.setStart(DateTime(2025));
+        expect(newInterval.start, DateTime(2024));
+        expect(newInterval.end, DateTime(2025));
+      });
+    });
+
+    group("setEnd", () {
+      test('new end is after old end', () {
+        final interval = Interval(DateTime(2022), DateTime(2024));
+        final newInterval = interval.setEnd(DateTime(2025));
+        expect(newInterval.start, DateTime(2022));
+        expect(newInterval.end, DateTime(2025));
+      });
+
+      test('new end is before old end', () {
+        final interval = Interval(DateTime(2022), DateTime(2024));
+        final newInterval = interval.setEnd(DateTime(2023));
+        expect(newInterval.start, DateTime(2022));
+        expect(newInterval.end, DateTime(2023));
+      });
+
+      test('new end is same as old end', () {
+        final interval = Interval(DateTime(2022), DateTime(2025));
+        final newInterval = interval.setEnd(DateTime(2025));
+        expect(newInterval.start, DateTime(2022));
+        expect(newInterval.end, DateTime(2025));
+      });
+
+      test('new end is before old start', () {
+        final interval = Interval(DateTime(2022), DateTime(2024));
+        final newInterval = interval.setEnd(DateTime(2021));
+        expect(newInterval.start, DateTime(2021));
+        expect(newInterval.end, DateTime(2022));
+      });
+    });
+
+    group("intersection", () {
+      test('first before second', () {
+        final firstInterval = Interval(DateTime(2022), DateTime(2024));
+        final secondInterval = Interval(DateTime(2023), DateTime(2025));
+
+        expect(firstInterval.intersection(secondInterval),
+            Interval(DateTime(2023), DateTime(2024)));
+      });
+      test('second before first', () {
+        final firstInterval = Interval(DateTime(2023), DateTime(2025));
+        final secondInterval = Interval(DateTime(2022), DateTime(2024));
+
+        expect(firstInterval.intersection(secondInterval),
+            Interval(DateTime(2023), DateTime(2024)));
+      });
+      test('start is equal', () {
+        final firstInterval = Interval(DateTime(2022), DateTime(2025));
+        final secondInterval = Interval(DateTime(2022), DateTime(2024));
+
+        expect(firstInterval.intersection(secondInterval),
+            Interval(DateTime(2022), DateTime(2024)));
+      });
+      test('end is equal', () {
+        final firstInterval = Interval(DateTime(2023), DateTime(2025));
+        final secondInterval = Interval(DateTime(2022), DateTime(2025));
+
+        expect(firstInterval.intersection(secondInterval),
+            Interval(DateTime(2023), DateTime(2025)));
+      });
+
+      test("return null if the intervals don't cross", () {
+        final firstInterval = Interval(DateTime(2023), DateTime(2025));
+        final secondInterval = Interval(DateTime(2026), DateTime(2027));
+
+        expect(
+          firstInterval.intersection(secondInterval),
+          null,
+        );
+      });
+
+      test('first is inside second', () {
+        final firstInterval = Interval(DateTime(2023), DateTime(2024));
+        final secondInterval = Interval(DateTime(2022), DateTime(2025));
+
+        expect(firstInterval.intersection(secondInterval),
+            Interval(DateTime(2023), DateTime(2024)));
+      });
+
+      test('second is inside first', () {
+        final firstInterval = Interval(DateTime(2022), DateTime(2025));
+        final secondInterval = Interval(DateTime(2023), DateTime(2024));
+
+        expect(firstInterval.intersection(secondInterval),
+            Interval(DateTime(2023), DateTime(2024)));
+      });
+    });
+    group("symmetricDifference", () {
+      test('first is inside second', () {
+        final firstInterval = Interval(DateTime(2022), DateTime(2025));
+        final secondInterval = Interval(DateTime(2023), DateTime(2024));
+
+        final symmetricDifference =
+            firstInterval.symmetricDifference(secondInterval);
+
+        expect(symmetricDifference, [
+          Interval(DateTime(2022), DateTime(2023)),
+          Interval(DateTime(2024), DateTime(2025))
+        ]);
+      });
+
+      test('second is inside first', () {
+        final firstInterval = Interval(DateTime(2023), DateTime(2024));
+        final secondInterval = Interval(DateTime(2022), DateTime(2025));
+
+        final symmetricDifference =
+            firstInterval.symmetricDifference(secondInterval);
+
+        expect(symmetricDifference, [
+          Interval(DateTime(2022), DateTime(2023)),
+          Interval(DateTime(2024), DateTime(2025))
+        ]);
+      });
+
+      test('first and second starts same day, second ends before first', () {
+        final firstInterval = Interval(DateTime(2022), DateTime(2025));
+        final secondInterval = Interval(DateTime(2022), DateTime(2024));
+
+        final symmetricDifference =
+            firstInterval.symmetricDifference(secondInterval);
+
+        expect(symmetricDifference, [Interval(DateTime(2024), DateTime(2025))]);
+      });
+
+      test('first and second starts same day, second ends after first', () {
+        final firstInterval = Interval(DateTime(2022), DateTime(2024));
+        final secondInterval = Interval(DateTime(2022), DateTime(2025));
+
+        final symmetricDifference =
+            firstInterval.symmetricDifference(secondInterval);
+
+        expect(symmetricDifference, [Interval(DateTime(2024), DateTime(2025))]);
+      });
+
+      test('first and second ends same day, second starts before first', () {
+        final firstInterval = Interval(DateTime(2024), DateTime(2025));
+        final secondInterval = Interval(DateTime(2022), DateTime(2025));
+
+        final symmetricDifference =
+            firstInterval.symmetricDifference(secondInterval);
+
+        expect(symmetricDifference, [Interval(DateTime(2022), DateTime(2024))]);
+      });
+
+      test('first and second ends same day, second starts after first', () {
+        final firstInterval = Interval(DateTime(2022), DateTime(2025));
+        final secondInterval = Interval(DateTime(2023), DateTime(2025));
+
+        final symmetricDifference =
+            firstInterval.symmetricDifference(secondInterval);
+
+        expect(symmetricDifference, [Interval(DateTime(2022), DateTime(2023))]);
+      });
+
+      test("first and second are equal", () {
+        final firstInterval = Interval(DateTime(2022), DateTime(2025));
+        final secondInterval = Interval(DateTime(2022), DateTime(2025));
+
+        final symmetricDifference =
+            firstInterval.symmetricDifference(secondInterval);
+
+        expect(symmetricDifference, []);
+      });
+
+      test("first and second are equal, but one is reversed", () {
+        final firstInterval = Interval(DateTime(2022), DateTime(2025));
+        final secondInterval = Interval(DateTime(2025), DateTime(2022));
+
+        final symmetricDifference =
+            firstInterval.symmetricDifference(secondInterval);
+
+        expect(symmetricDifference, []);
+      });
+
+      test("date don't overlap", () {
+        final firstInterval = Interval(DateTime(2022), DateTime(2025));
+        final secondInterval = Interval(DateTime(2026), DateTime(2027));
+
+        final symmetricDifference =
+            firstInterval.symmetricDifference(secondInterval);
+
+        expect(symmetricDifference, [
+          Interval(DateTime(2022), DateTime(2025)),
+          Interval(DateTime(2026), DateTime(2027))
+        ]);
+      });
+
+      /////
+    });
+  });
+}


### PR DESCRIPTION
v1.4.0

- **!!! BREAKING CHANGE** `Interval` can accept negative values
- Some methods that used to throw an error now return null instead
- Fix type with `symetricDifference` to `symmetricDifference`, marking the other one as deprecated @praiaBarryTolnas #39
- **!!! BREAKING CHANGE** Change extension name from `Date` to `DateTimeExtension` @tjarvstrand #38 - static methods are now exported from `DateTimeExtension._` instead of `Date._`