### PR TITLE
Fix the nextWeek/previousWeek calculation during daylight savings

### DIFF
--- a/lib/src/dart_date.dart
+++ b/lib/src/dart_date.dart
@@ -868,10 +868,10 @@ extension DateTimeExtension on DateTime {
   DateTime get previousYear => clone.setYear(year - 1);
 
   /// The week after this [DateTime]
-  DateTime get nextWeek => addDays(7);
+  DateTime get nextWeek => addDays(7, true);
 
   /// The week previous this [DateTime]
-  DateTime get previousWeek => subDays(7);
+  DateTime get previousWeek => subDays(7, true);
 
   /// Number of seconds since epoch time
   ///


### PR DESCRIPTION
Problem: If the week is longer than 7 * 24 * 60 (due to daylight savings weeks), the result of nextWeek/previousWeek is incorrect

Solution: use methods that modify the day number instead of adding duration